### PR TITLE
Catching errors from request

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -98,6 +98,10 @@ PoliteRobot.prototype.allowed = function (url) {
   }).then(function (access) {
     that.log('We', access ? 'are' : 'are NOT', 'allowed to fetch', urlModule.parse(url).hostname + '' + urlModule.parse(url).pathname);
     return access;
+  }).catch(function (err) {
+    // RC: Catch errors from request because of bad SSL cert, for instance. This
+    //     may only happen when calling allowed() directly as udu happens to do.
+    return true;
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "fetch-politely",
   "version": "0.7.1",
   "description": "Ensures polite outgoing HTTP requests that respects robots.txt and aren't made too close to each other",
-  "homepage": "https://github.com/uduinc/udu-node-fetch-politely",
+  "homepage": "http://github.com/voxpelli/node-fetch-politely",
   "repository": {
     "type": "git",
-    "url": "https://github.com/uduinc/udu-node-fetch-politely.git"
+    "url": "git://github.com/voxpelli/node-fetch-politely.git"
   },
   "author": {
     "name": "Pelle Wessman",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "fetch-politely",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Ensures polite outgoing HTTP requests that respects robots.txt and aren't made too close to each other",
-  "homepage": "http://github.com/voxpelli/node-fetch-politely",
+  "homepage": "https://github.com/uduinc/udu-node-fetch-politely",
   "repository": {
     "type": "git",
-    "url": "git://github.com/voxpelli/node-fetch-politely.git"
+    "url": "https://github.com/uduinc/udu-node-fetch-politely.git"
   },
   "author": {
     "name": "Pelle Wessman",


### PR DESCRIPTION
We've found it necessary to add a catch function to the allowed Promise section in robot.js. Note, that this may be peculiar to our particular implementation. If so, you can certainly disregard, but I'm not sure this would hurt other forms of implementation so you may want to keep it.

A url to test against is: https://egov.uscis.gov/crisgwi/go?action=offices.detail&office=XSF&OfficeLocator.office_type=ASC&OfficeLocator.statecode=MT

It will receive an error from request about a bad SSL certificate. That error was causing the promise to never resolve.